### PR TITLE
With strict compiler settings returning CAAnimation * from indeterminate property fails to compile.

### DIFF
--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -213,7 +213,7 @@
 - (NSInteger)indeterminate
 {
     CAAnimation *spinAnimation = [self.layer animationForKey:@"indeterminateAnimation"];
-    return spinAnimation;
+    return spinAnimation == nil ? 0 : 1;
 }
 
 - (void)setIndeterminate:(NSInteger)indeterminate


### PR DESCRIPTION
The existing code fails with strict compiler settings. Return 0 if not
indeterminate, 1 if it is.

DACircularProgressView.m:216:12: error: incompatible pointer to integer
conversion returning 'CAAnimation *__strong' from a function with
result type 'NSInteger' (aka 'int');  [-Werror]
return spinAnimation;
