### PR TITLE
Added initial delay feature: optional property to delay the animation.

### DIFF
--- a/DACircularProgress/DACircularProgressView.h
+++ b/DACircularProgress/DACircularProgressView.h
@@ -21,5 +21,6 @@
 @property(nonatomic) NSInteger indeterminate UI_APPEARANCE_SELECTOR; // Can not use BOOL with UI_APPEARANCE_SELECTOR :-(
 
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
+- (void)setProgress:(CGFloat)progress animated:(BOOL)animated initialDelay:(CFTimeInterval)initialDelay;
 
 @end

--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -175,6 +175,13 @@
 
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated
 {
+    [self setProgress:progress animated:animated initialDelay:0.0];
+}
+
+- (void)setProgress:(CGFloat)progress
+           animated:(BOOL)animated
+       initialDelay:(CFTimeInterval)initialDelay
+{
     [self.layer removeAnimationForKey:@"indeterminateAnimation"];
     [self.circularProgressLayer removeAnimationForKey:@"progress"];
     
@@ -185,11 +192,19 @@
         animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
         animation.fromValue = [NSNumber numberWithFloat:self.progress];
         animation.toValue = [NSNumber numberWithFloat:pinnedProgress];
+        animation.beginTime = CACurrentMediaTime() + initialDelay;
+        animation.delegate = self;
         [self.circularProgressLayer addAnimation:animation forKey:@"progress"];
     } else {
         [self.circularProgressLayer setNeedsDisplay];
+        self.circularProgressLayer.progress = pinnedProgress;
     }
-    self.circularProgressLayer.progress = pinnedProgress;
+}
+
+- (void)animationDidStop:(CAAnimation *)animation finished:(BOOL)flag
+{
+   NSNumber *pinnedProgressNumber = [animation valueForKey:@"toValue"];
+   self.circularProgressLayer.progress = [pinnedProgressNumber floatValue];
 }
 
 #pragma mark - UIAppearance methods


### PR DESCRIPTION
Verified in testing that this works, but there is a slight flicker at the end of the animation. I believe this is due to the storing of the progress on circularProgressLayer at the end of the animation. That progress cannot be stored before the animation starts, otherwise during the initial delay the new value is already visible. Would love to know how to improve on this.

In any case, I found this option to delay the animation (e.g. by half a second) very useful. 

Thanks for making the DACircularProgress openly available.

Erik
