### PR TITLE
Fixed labeled view being white in iOS < 7

### DIFF
--- a/DACircularProgress/DALabeledCircularProgressView.m
+++ b/DACircularProgress/DALabeledCircularProgressView.m
@@ -39,6 +39,7 @@
     self.progressLabel = [[UILabel alloc]
                           initWithFrame:self.bounds];
     self.progressLabel.textAlignment = NSTextAlignmentCenter;
+    self.progressLabel.backgroundColor = [UIColor clearColor];
     [self addSubview:self.progressLabel];
 }
 


### PR DESCRIPTION
DALabeledCircularProgressView would appear white in iOS 5 and 6 as the default background colour was white. Setting the background to clear fixes this bug so it behaves as intended like in iOS 7.
