### PR TITLE
fixing minor warning with converting PI double to a float NSNumber

### DIFF
--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -263,7 +263,7 @@
 {
     if (indeterminate && !self.indeterminate) {
         CABasicAnimation *spinAnimation = [CABasicAnimation animationWithKeyPath:@"transform.rotation"];
-        spinAnimation.byValue = [NSNumber numberWithFloat:indeterminate > 0 ? 2.0f*M_PI : -2.0f*M_PI];
+        spinAnimation.byValue = [NSNumber numberWithDouble:indeterminate > 0 ? 2.0f*M_PI : -2.0f*M_PI];
         spinAnimation.duration = self.indeterminateDuration;
         spinAnimation.repeatCount = HUGE_VALF;
         [self.layer addAnimation:spinAnimation forKey:@"indeterminateAnimation"];


### PR DESCRIPTION
This is a very minor change but it silences an implicit conversion warning that XCode gives with stricter type checking.
