### PR TITLE
Fixes flicker when progress animation completes

### DIFF
--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -190,6 +190,7 @@
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"progress"];
         animation.duration = fabsf(self.progress - pinnedProgress); // Same duration as UIProgressView animation
         animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        animation.fillMode = kCAFillModeForwards;
         animation.fromValue = [NSNumber numberWithFloat:self.progress];
         animation.toValue = [NSNumber numberWithFloat:pinnedProgress];
         animation.beginTime = CACurrentMediaTime() + initialDelay;


### PR DESCRIPTION
This fixes the flicker seen when the progress animation completes, as mentioned in issue #30. The way your example project is currently setup, you don't actually see the flicker. Here's how you can test it:

I'm using iOS7 base SDK and iPhone Retina (4-inch 64-bit) simulator. In `ViewController.m` comment out `[self startAnimation];` on line 53 and add in `[self.progressView setProgress:0.7 animated:YES];`.

Run the app and notice the flicker when the animation completes. Merge this branch and confirm the flicker is fixed.
