### PR TITLE
The warning moved to here :/

### DIFF
--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -194,7 +194,7 @@
     [self setProgress:progress
              animated:animated
          initialDelay:initialDelay
-         withDuration:fabsf(self.progress - pinnedProgress)];
+         withDuration:fabs(self.progress - pinnedProgress)];
 }
 
 - (void)setProgress:(CGFloat)progress


### PR DESCRIPTION
After looking at the 2.3.0 tag, I noticed the warning just moved, it wasn't actually resolved. This resolves the warning in Xcode 6.3 6D570