### PR TITLE
Custom timing function. Check animation

### DIFF
--- a/DACircularProgress/DACircularProgressView.h
+++ b/DACircularProgress/DACircularProgressView.h
@@ -21,6 +21,8 @@
 @property(nonatomic) CGFloat indeterminateDuration UI_APPEARANCE_SELECTOR;
 @property(nonatomic) NSInteger indeterminate UI_APPEARANCE_SELECTOR; // Can not use BOOL with UI_APPEARANCE_SELECTOR :-(
 
+@property(nonatomic, strong) CAMediaTimingFunction* animationTimingFunction;
+
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated initialDelay:(CFTimeInterval)initialDelay;
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated initialDelay:(CFTimeInterval)initialDelay withDuration:(CFTimeInterval)duration;

--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -209,7 +209,7 @@
     if (animated) {
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"progress"];
         animation.duration = duration;
-        animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+        animation.timingFunction = self.animationTimingFunction ?: [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
         animation.fillMode = kCAFillModeForwards;
         animation.fromValue = [NSNumber numberWithFloat:self.progress];
         animation.toValue = [NSNumber numberWithFloat:pinnedProgress];
@@ -224,10 +224,11 @@
 
 - (void)animationDidStop:(CAAnimation *)animation finished:(BOOL)flag
 {
-   NSNumber *pinnedProgressNumber = [animation valueForKey:@"toValue"];
-   self.circularProgressLayer.progress = [pinnedProgressNumber floatValue];
+   if ([self.circularProgressLayer animationForKey: @"progress"] == animation) {
+      NSNumber *pinnedProgressNumber = [animation valueForKey:@"toValue"];
+      self.circularProgressLayer.progress = [pinnedProgressNumber floatValue];
+   }
 }
-
 
 #pragma mark - UIAppearance methods
 


### PR DESCRIPTION
1) In my case animation should be like clock, so I needed linear animation. That is why custom timing function was added

2) Animation in delegate should be checked. As mentioned below code is broken:
self.progressView.setProgress(1.0, animated: true)
//....and when I call during animation progress
self.progressView.setProgress(0.5, animated: false)
last call initiates remove of animation. And it calls animationDidStop delegate method asynchronously, even after proper progress is set. So after 0.5 is set, 1.0 will be in a moment
