### PR TITLE
Explicitly declare delegate conformance

### DIFF
--- a/DACircularProgress/DACircularProgressView.h
+++ b/DACircularProgress/DACircularProgressView.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface DACircularProgressView : UIView
+@interface DACircularProgressView : UIView <CAAnimationDelegate>
 
 @property(nonatomic, strong) UIColor *trackTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *progressTintColor UI_APPEARANCE_SELECTOR;


### PR DESCRIPTION
This fixes the following warning in Xcode 8:

DACircularProgress/DACircularProgressView.m:218:28: Assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type 'DACircularProgressView *const __strong'
