### PR TITLE
fix Assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type 'DACircularProgressView *const __strong'

### DIFF
--- a/DACircularProgress/DACircularProgressView.h
+++ b/DACircularProgress/DACircularProgressView.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface DACircularProgressView : UIView
+@interface DACircularProgressView : UIView <CAAnimationDelegate>
 
 @property(nonatomic, strong) UIColor *trackTintColor UI_APPEARANCE_SELECTOR;
 @property(nonatomic, strong) UIColor *progressTintColor UI_APPEARANCE_SELECTOR;


### PR DESCRIPTION
fixed Assigning to 'id<CAAnimationDelegate> _Nullable' from incompatible type 'DACircularProgressView *const __strong' by adding CAAnimationDelegate