### PR TITLE
let DACircularProgressView conform the protocol CAAnimationDelegate.

### DIFF
--- a/DACircularProgress/DACircularProgressView.m
+++ b/DACircularProgress/DACircularProgressView.m
@@ -123,7 +123,7 @@
 
 @end
 
-@interface DACircularProgressView ()
+@interface DACircularProgressView () <CAAnimationDelegate>
 
 @end
 


### PR DESCRIPTION
let DACircularProgressView become the CABasicAnimation delegate,· must conform the protocol CAAnimationDelegate.· If not , there was a warning in project.